### PR TITLE
new: detecting local registry port dynamically (ENG-130)

### DIFF
--- a/dreadnode_cli/agent/docker.py
+++ b/dreadnode_cli/agent/docker.py
@@ -8,12 +8,34 @@ from rich.live import Live
 from rich.text import Text
 
 from dreadnode_cli.config import ServerConfig
-from dreadnode_cli.defaults import DOCKER_REGISTRY_SUBDOMAIN, PLATFORM_BASE_DOMAIN
+from dreadnode_cli.defaults import (
+    DOCKER_REGISTRY_IMAGE_TAG,
+    DOCKER_REGISTRY_LOCAL_PORT,
+    DOCKER_REGISTRY_SUBDOMAIN,
+    PLATFORM_BASE_DOMAIN,
+)
 
 try:
     client = docker.from_env()
 except docker.errors.DockerException:
     client = None
+
+
+def get_local_registry_port() -> int:
+    if client is None:
+        raise Exception("Docker not available")
+
+    for container in client.containers.list():
+        if DOCKER_REGISTRY_IMAGE_TAG in container.image.tags:
+            ports = container.attrs["NetworkSettings"]["Ports"]
+            assert len(ports) == 1
+            for _container_port, port_bindings in ports.items():
+                if port_bindings:
+                    for binding in port_bindings:
+                        return int(binding["HostPort"])
+
+    # fallback to the default port if we can't find the running container
+    return DOCKER_REGISTRY_LOCAL_PORT
 
 
 def get_registry(config: ServerConfig) -> str:
@@ -22,9 +44,8 @@ def get_registry(config: ServerConfig) -> str:
         raise Exception("Docker not available")
 
     # localhost is a special case
-    # TODO: Can we get this port dynamically?
     if "localhost" in config.url or "127.0.0.1" in config.url:
-        return "localhost:5005"
+        return f"localhost:{get_local_registry_port()}"
 
     prefix = ""
     if "staging-" in config.url:

--- a/dreadnode_cli/defaults.py
+++ b/dreadnode_cli/defaults.py
@@ -14,6 +14,11 @@ PLATFORM_BASE_DOMAIN = "dreadnode.io"
 PLATFORM_BASE_URL = os.getenv("DREADNODE_SERVER", f"https://crucible.{PLATFORM_BASE_DOMAIN}")
 # default docker registry subdomain
 DOCKER_REGISTRY_SUBDOMAIN = "registry"
+# default docker registry local port
+DOCKER_REGISTRY_LOCAL_PORT = 5005
+# default docker registry image tag
+DOCKER_REGISTRY_IMAGE_TAG = "registry"
+
 # path to the user configuration file
 USER_CONFIG_PATH = pathlib.Path(
     # allow overriding the user config file via env variable


### PR DESCRIPTION
* Added local docker registry port detection by inspecting running containers with 'registry' tag, fallback to default port if nothing found.
* Added unit tests for both conditions.