### PR TITLE
refactor: decoupled strike run status literal from cli

### DIFF
--- a/dreadnode_cli/agent/cli.py
+++ b/dreadnode_cli/agent/cli.py
@@ -203,7 +203,7 @@ def deploy(
         return
 
     with Live(formatted, refresh_per_second=2) as live:
-        while run.status not in ["completed", "failed", "timeout"]:
+        while run.is_running():
             time.sleep(1)
             run = client.get_strike_run(run.id)
             live.update(format_run(run))

--- a/dreadnode_cli/api.py
+++ b/dreadnode_cli/api.py
@@ -353,6 +353,9 @@ class Client:
         start: datetime | None
         end: datetime | None
 
+        def is_running(self) -> bool:
+            return self.status not in ["completed", "failed", "timeout", "terminated"]
+
     class StrikeRunSummaryResponse(_StrikeRun):
         zones: list["Client.StrikeRunZoneSummary"]
 


### PR DESCRIPTION
Closes https://linear.app/dreadnode/issue/ENG-179/cli-decouple-strikerunstatus-literal-values-from-agentclideploy