### PR TITLE
fix: suggestion for handling terminated deploys

### DIFF
--- a/dreadnode_cli/agent/cli.py
+++ b/dreadnode_cli/agent/cli.py
@@ -328,11 +328,18 @@ def deploy(
         print(formatted)
         return
 
-    with Live(formatted, refresh_per_second=2) as live:
-        while run.is_running():
-            time.sleep(1)
-            run = client.get_strike_run(run.id)
-            live.update(format_run(run))
+    try:
+        with Live(formatted, refresh_per_second=2) as live:
+            while run.is_running():
+                time.sleep(1)
+                run = client.get_strike_run(run.id)
+                live.update(format_run(run))
+    except KeyboardInterrupt:
+        print("\n:warning: Terminating run...")
+        client.terminate_strike_run(run.id)
+        run = client.get_strike_run(run.id)
+        print(format_run(run))
+        return
 
 
 @cli.command(help="List available models for the current (or specified) strike")

--- a/dreadnode_cli/api.py
+++ b/dreadnode_cli/api.py
@@ -448,6 +448,11 @@ class Client:
         response = self.request("GET", f"/api/strikes/runs/{run}")
         return self.StrikeRunResponse(**response.json())
 
+    def terminate_strike_run(self, run: UUID | str) -> StrikeRunResponse:
+        """Terminate a running strike."""
+        response = self.request("POST", f"/api/strikes/runs/{run}/terminate")
+        return self.StrikeRunResponse(**response.json())
+
     def list_strike_runs(self, *, strike_id: UUID | str | None = None) -> list[StrikeRunSummaryResponse]:
         response = self.request(
             "GET", "/api/strikes/runs", query_params={"strike_id": str(strike_id)} if strike_id else None


### PR DESCRIPTION
i noticed that locally, when aborting the agent deploy still reflects running and doesnt look to terminate according to the UI and cli:
![image](https://github.com/user-attachments/assets/4a91d903-b7e2-4665-b5eb-9cdc8706d347)
```shell
╭─────────────┬────────────────────────────────────────────────────╮
│          id │ 00fb725c-3dd2-405a-ab44-93af79972788               │
│         key │ khaki-mustang                                      │
│        name │ -                                                  │
│    revision │ 1                                                  │
│ last status │ deploying                                          │
│     created │ Tue Dec 17 13:25:34 2024                           │
│             │                                                    │
│      latest │ ╭─────────┬──────────────────────────────────────╮ │
│             │ │      id │ 106c84c4-c5df-48c8-8f3a-15c3770af5bd │ │
│             │ │ created │ Tue Dec 17 13:25:34 2024             │ │
│             │ │   notes │ ads first iteration                  │ │
│             │ ╰─────────┴──────────────────────────────────────╯ │
╰─────────────┴────────────────────────────────────────────────────╯
```
suggestion fix, apologies if im missing some kind of context or anything here 🙂 