### PR TITLE
feat: Assign strike runs to groups (ENG-981) 

### DIFF
--- a/dreadnode_cli/agent/cli.py
+++ b/dreadnode_cli/agent/cli.py
@@ -18,6 +18,7 @@ from dreadnode_cli.agent.format import (
     format_agent,
     format_agent_versions,
     format_run,
+    format_run_groups,
     format_runs,
     format_strike_models,
     format_strikes,
@@ -67,7 +68,9 @@ def ensure_profile(agent_config: AgentConfig, *, user_config: UserConfig | None 
         ):
             print()
             raise Exception(
-                "Agent link does not match the current server profile. Use [bold]dreadnode agent switch[/] or [bold]dreadnode profile switch[/]."
+                f"Current agent link ([yellow]{agent_config.active_link.profile}[/]) does not match "
+                f"the current server profile ([magenta]{user_config.active_profile_name}[/]). "
+                "Use [bold]dreadnode agent switch[/] or [bold]dreadnode profile switch[/]."
             )
 
         switch_profile(agent_config.active_link.profile)
@@ -247,7 +250,14 @@ def push(
 
     if agent_config.links and not agent_config.has_link_to_profile(user_config.active_profile_name):
         print(f":link: Linking as a fresh agent to the current profile [magenta]{user_config.active_profile_name}[/]")
+        print()
         new = True
+    elif agent_config.active and agent_config.active_link.profile != user_config.active_profile_name:
+        raise Exception(
+            f"Current agent link ([yellow]{agent_config.active_link.profile}[/]) does not match "
+            f"the current server profile ([magenta]{user_config.active_profile_name}[/]). "
+            "Use [bold]dreadnode agent switch[/] or [bold]dreadnode profile switch[/]."
+        )
 
     server_config = user_config.get_server_config()
 
@@ -330,6 +340,7 @@ def deploy(
     ] = pathlib.Path("."),
     strike: t.Annotated[str | None, typer.Option("--strike", "-s", help="The strike to use for this run")] = None,
     watch: t.Annotated[bool, typer.Option("--watch", "-w", help="Watch the run status")] = True,
+    group: t.Annotated[str | None, typer.Option("--group", "-g", help="Group to associate this run with")] = None,
 ) -> None:
     agent_config = AgentConfig.read(directory)
     ensure_profile(agent_config)
@@ -376,7 +387,9 @@ def deploy(
                 f"Model '{model}' is not user-defined nor is it available in strike '{strike_response.name}'"
             )
 
-    run = client.start_strike_run(agent.latest_version.id, strike=strike, model=model, user_model=user_model)
+    run = client.start_strike_run(
+        agent.latest_version.id, strike=strike, model=model, user_model=user_model, group=group
+    )
     agent_config.add_run(run.id).write(directory)
     formatted = format_run(run, server_url=server_config.url)
 
@@ -567,6 +580,14 @@ def switch(
             return
 
     print(f":exclamation: '{agent_or_profile}' not found, use [bold]dreadnode agent links[/]")
+
+
+@cli.command(help="List strike run groups")
+@pretty_cli
+def run_groups() -> None:
+    client = api.create_client()
+    groups = client.list_strike_run_groups()
+    print(format_run_groups(groups))
 
 
 @cli.command(help="Clone a github repository", no_args_is_help=True)

--- a/dreadnode_cli/agent/tests/test_config.py
+++ b/dreadnode_cli/agent/tests/test_config.py
@@ -121,7 +121,7 @@ def test_ensure_profile() -> None:
     agent_config.add_link("test-main", UUID("00000000-0000-0000-0000-000000000000"), "main")
     agent_config.active = "test-other"
     with patch("rich.prompt.Prompt.ask", return_value="n"):
-        with pytest.raises(Exception, match="Agent link does not match the current server profile"):
+        with pytest.raises(Exception, match="Current agent link"):
             ensure_profile(agent_config, user_config=user_config)
 
     # We should switch if the user agrees


### PR DESCRIPTION
- Add --group arg to deploy for assigning runs to groups.
- Add run-groups subcommand for listing them.
- Structure some formatting.
- Small bug fix regarding agent links.